### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dvisvgm (2.9.1-2) UNRELEASED; urgency=low
+
+  * debian/copyright: use spaces rather than tabs to start continuation lines.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Fri, 31 Jul 2020 11:34:14 -0000
+
 dvisvgm (2.9.1-1) unstable; urgency=medium
 
   * New upstream release (Closes: #956484).

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 dvisvgm (2.9.1-2) UNRELEASED; urgency=low
 
   * debian/copyright: use spaces rather than tabs to start continuation lines.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Fri, 31 Jul 2020 11:34:14 -0000
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -41,7 +41,7 @@ License: Boost-Software-License
 
 Files: libs/ff-woff/*
 Copyright: 2000 to 2012 George Williams
-	2012 to 2019 The FontForge community
+ 	2012 to 2019 The FontForge community
 License: GPL-3+
 
 Files: libs/md5/*

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/mgieseki/dvisvgm/issues
+Bug-Submit: https://github.com/mgieseki/dvisvgm/issues/new
+Repository: https://github.com/mgieseki/dvisvgm.git
+Repository-Browse: https://github.com/mgieseki/dvisvgm


### PR DESCRIPTION
Fix some issues reported by lintian
* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/dvisvgm/50c69885-d145-4a8e-8c98-abcb86ad950b.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/50c69885-d145-4a8e-8c98-abcb86ad950b/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/50c69885-d145-4a8e-8c98-abcb86ad950b/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/50c69885-d145-4a8e-8c98-abcb86ad950b/diffoscope)).
